### PR TITLE
Workaround for missing classic config

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build Docker image
         if: github.ref == 'refs/heads/master'
         run: >
-          mvn --batch-mode jib:build
+          mvn --batch-mode -Padd-classic-config jib:build
           -Djib.httpTimeout=60000
           -Djib.to.image=docker.io/powsybl/case-server
           -Djib.to.auth.username=powsyblci

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,16 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>add-classic-config</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.powsybl</groupId>
+                    <artifactId>powsybl-config-classic</artifactId>
+                    <version>${powsybl-core.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <dependencyManagement>
@@ -244,7 +254,6 @@
         </dependency>
 
         <!-- Runtime dependencies -->
-
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-xml-converter</artifactId>
@@ -252,14 +261,15 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-ucte-converter</artifactId>
+            <artifactId>powsybl-cgmes-conversion</artifactId>
             <version>${powsybl-core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-cgmes-conversion</artifactId>
+            <artifactId>powsybl-ucte-converter</artifactId>
             <version>${powsybl-core.version}</version>
         </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>com.google.jimfs</groupId>
@@ -267,6 +277,13 @@
             <version>${jimfs.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-config-test</artifactId>
@@ -277,12 +294,6 @@
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-impl</artifactId>
             <version>${powsybl-core.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Web service does not work anymore as config-classic dependency is missing. There is a design issue powsybl core config that forbid having a classic and test dependency in the classpath. 


**What is the new behavior (if this is a feature change)?**
As a workaround, classic-config is added by a profile and should not be activated at the same time as tests.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
