### PR TITLE
Handle exception when getCases processes corrupted cases

### DIFF
--- a/src/main/java/com/powsybl/caseserver/CaseService.java
+++ b/src/main/java/com/powsybl/caseserver/CaseService.java
@@ -111,10 +111,20 @@ public class CaseService {
     public List<CaseInfos> getCases(Path directory) {
         try (Stream<Path> walk = Files.walk(directory)) {
             return walk.filter(Files::isRegularFile)
-                .map(file -> createInfos(file.getFileName().toString(), UUID.fromString(file.getParent().getFileName().toString()), getFormat(file)))
-                .collect(Collectors.toList());
+                    .map(this::getCaseInfos)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
+        }
+    }
+
+    private CaseInfos getCaseInfos(Path file) {
+        try {
+            return createInfos(file.getFileName().toString(), UUID.fromString(file.getParent().getFileName().toString()), getFormat(file));
+        } catch (Exception e) {
+            LOGGER.error("Error processing file {}: {}", file.getFileName(), e.getMessage(), e);
+            return null;
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?**
When using the endpoint GET v1/cases or POST v1/cases/reindex-all, a 500 Internal Server Error is thrown when there are corrupted cases in the cases/ directory (e.g file that are not completely imported, file that are not network files, etc.) and the file name of the corrupted file is not logged.

Instead of throwing and stopping the execution, we log the error and continue to the next file. In the error log, there is the name of the file that was not processed correctly to help diagnosing further the issue.

**Other information**:
To test this, one can add a ".txt" file in the /cases directory or add a corrupted file in the /cases/{uuid} directory.   
