### PR TITLE
Fix case names when exported

### DIFF
--- a/src/main/java/com/powsybl/caseserver/CaseService.java
+++ b/src/main/java/com/powsybl/caseserver/CaseService.java
@@ -15,6 +15,7 @@ import com.powsybl.caseserver.parsers.FileNameParsers;
 import com.powsybl.caseserver.repository.CaseMetadataEntity;
 import com.powsybl.caseserver.repository.CaseMetadataRepository;
 import com.powsybl.commons.datasource.DataSource;
+import com.powsybl.commons.datasource.DataSourceUtil;
 import com.powsybl.commons.datasource.MemDataSource;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.computation.local.LocalComputationManager;
@@ -425,8 +426,7 @@ public class CaseService {
             network.write(format, exportProperties, memDataSource);
 
             var listNames = memDataSource.listNames(".*");
-            // the network name corresponds to the case file base name
-            String networkName = network.getNameOrId();
+            String networkName = DataSourceUtil.getBaseName(getCaseName(caseUuid));
             byte[] networkData;
             if (listNames.size() == 1) {
                 String extension = listNames.iterator().next();

--- a/src/main/java/com/powsybl/caseserver/CaseService.java
+++ b/src/main/java/com/powsybl/caseserver/CaseService.java
@@ -426,7 +426,8 @@ public class CaseService {
             network.write(format, exportProperties, memDataSource);
 
             var listNames = memDataSource.listNames(".*");
-            String networkName = FilenameUtils.removeExtension(getCaseName(caseUuid));
+            // the network name corresponds to the case file base name
+            String networkName = network.getNameOrId();
             byte[] networkData;
             if (listNames.size() == 1) {
                 String extension = listNames.iterator().next();

--- a/src/main/java/com/powsybl/caseserver/CaseService.java
+++ b/src/main/java/com/powsybl/caseserver/CaseService.java
@@ -21,7 +21,6 @@ import com.powsybl.computation.local.LocalComputationManager;
 import com.powsybl.iidm.network.Exporter;
 import com.powsybl.iidm.network.Importer;
 import com.powsybl.iidm.network.Network;
-import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
we extract the right base name in cases with extension like '.xml.gz' when we do the export.
Example: converting 'recollement-20230921-1900-enrichi.xml.gz' into xiidm format will be 'recollement-20230921-1900-enrichi.xiidm' 



**What is the current behavior?**
<!-- You can also link to an open issue here -->
It creates the converted file name by just removing the last extension from the source file.
Example: converting 'recollement-20230921-1900-enrichi.xml.gz' into xiidm format will be 'recollement-20230921-1900-enrichi.xml.xiidm' 


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
