### PR TITLE
Swallow exceptions in getCases() when some cases do not have case_metadata

### DIFF
--- a/src/main/java/com/powsybl/caseserver/service/CaseService.java
+++ b/src/main/java/com/powsybl/caseserver/service/CaseService.java
@@ -49,7 +49,7 @@ public interface CaseService {
     }
 
     default CaseMetadataEntity getCaseMetaDataEntity(UUID caseUuid) {
-        return getCaseMetadataRepository().findById(caseUuid).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "case " + caseUuid + NOT_FOUND));
+        return getCaseMetadataRepository().findById(caseUuid).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Metadata of case " + caseUuid + NOT_FOUND));
     }
 
     default Boolean isUploadedAsPlainFile(UUID caseUuid) {

--- a/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
+++ b/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
@@ -109,7 +109,7 @@ public class FsCaseService implements CaseService {
     }
 
     private CaseInfos getCaseInfos(Path file) {
-        CaseInfos caseInfos =  createInfos(file, UUID.fromString(file.getParent().getFileName().toString()));
+        CaseInfos caseInfos = createInfos(file, UUID.fromString(file.getParent().getFileName().toString()));
         return removeGzipExtensionFromPlainFile(caseInfos);
     }
 

--- a/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
+++ b/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
@@ -100,7 +100,7 @@ public class FsCaseService implements CaseService {
     public List<CaseInfos> getCases() {
         try (Stream<Path> walk = Files.walk(getStorageRootDir())) {
             return walk.filter(Files::isRegularFile)
-                    .map(this::getCaseInfosOrNull)
+                    .map(this::getCaseInfoSafely)
                     .filter(Objects::nonNull)
                     .toList();
         } catch (IOException e) {
@@ -113,7 +113,7 @@ public class FsCaseService implements CaseService {
         return removeGzipExtensionFromPlainFile(caseInfos);
     }
 
-    private CaseInfos getCaseInfosOrNull(Path file) {
+    private CaseInfos getCaseInfoSafely(Path file) {
         Objects.requireNonNull(file);
         try {
             return getCaseInfos(file);

--- a/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
+++ b/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
@@ -114,6 +114,7 @@ public class FsCaseService implements CaseService {
     }
 
     private CaseInfos getCaseInfosOrNull(Path file) {
+        Objects.requireNonNull(file);
         try {
             CaseInfos caseInfos = getCaseInfos(file);
             return Objects.nonNull(caseInfos) ? removeGzipExtensionFromPlainFile(caseInfos) : null;

--- a/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
+++ b/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
@@ -109,14 +109,14 @@ public class FsCaseService implements CaseService {
     }
 
     private CaseInfos getCaseInfos(Path file) {
-        return createInfos(file, UUID.fromString(file.getParent().getFileName().toString()));
+        CaseInfos caseInfos =  createInfos(file, UUID.fromString(file.getParent().getFileName().toString()));
+        return removeGzipExtensionFromPlainFile(caseInfos);
     }
 
     private CaseInfos getCaseInfosOrNull(Path file) {
         Objects.requireNonNull(file);
         try {
-            CaseInfos caseInfos = getCaseInfos(file);
-            return Objects.nonNull(caseInfos) ? removeGzipExtensionFromPlainFile(caseInfos) : null;
+            return getCaseInfos(file);
         } catch (Exception e) {
             // This method is called by getCases() that is a method for supervision and administration. We do not want the request to stop and fail on error cases.
             LOGGER.error("Error processing file {}: {}", file.getFileName(), e.getMessage(), e);
@@ -134,9 +134,6 @@ public class FsCaseService implements CaseService {
         if (caseInfos == null) {
             throw CaseException.createFileNameNotFound(caseUuid);
         }
-        if (Boolean.TRUE.equals(isUploadedAsPlainFile(caseUuid))) {
-            return removeExtension(caseInfos.getName(), GZIP_EXTENSION);
-        }
         return caseInfos.getName();
     }
 
@@ -147,8 +144,7 @@ public class FsCaseService implements CaseService {
             LOGGER.error("The directory with the following uuid doesn't exist: {}", caseUuid);
             return null;
         }
-        CaseInfos caseInfos = getCaseInfos(file);
-        return this.removeGzipExtensionFromPlainFile(caseInfos);
+        return getCaseInfos(file);
     }
 
     public Path getCaseFile(UUID caseUuid) {

--- a/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
+++ b/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
@@ -101,11 +101,20 @@ public class FsCaseService implements CaseService {
         try (Stream<Path> walk = Files.walk(getStorageRootDir())) {
             return walk.filter(Files::isRegularFile)
                     .map(this::getCaseInfos)
+                    .map(this::getCleanCaseInfos)
                     .filter(Objects::nonNull)
-                    .map(this::removeGzipExtensionFromPlainFile)
                     .toList();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
+        }
+    }
+
+    private CaseInfos getCleanCaseInfos (CaseInfos caseInfos) {
+        try {
+            return this.removeGzipExtensionFromPlainFile(caseInfos);
+        } catch (ResponseStatusException e) {
+            LOGGER.error("Error processing file {}: {}", caseInfos.getName(), e.getMessage(), e);
+            return null;
         }
     }
 

--- a/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
+++ b/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
@@ -108,19 +108,20 @@ public class FsCaseService implements CaseService {
         }
     }
 
+    private CaseInfos getCaseInfos(Path file) {
+        Objects.requireNonNull(file);
+        return createInfos(file, UUID.fromString(file.getParent().getFileName().toString()));
+    }
+
     private CaseInfos getCaseInfosOrNull(Path file) {
         try {
-            return removeGzipExtensionFromPlainFile(getCaseInfos(file));
+            CaseInfos caseInfos = getCaseInfos(file);
+            return Objects.nonNull(caseInfos) ? removeGzipExtensionFromPlainFile(caseInfos) : null;
         } catch (Exception e) {
             // This method is called by getCases() that is a method for supervision and administration. We do not want the request to stop and fail on an error cases.
             LOGGER.error("Error processing file {}: {}", file.getFileName(), e.getMessage(), e);
             return null;
         }
-    }
-
-    private CaseInfos getCaseInfos(Path file) {
-        Objects.requireNonNull(file);
-        return createInfos(file, UUID.fromString(file.getParent().getFileName().toString()));
     }
 
     @Override

--- a/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
+++ b/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
@@ -109,7 +109,6 @@ public class FsCaseService implements CaseService {
     }
 
     private CaseInfos getCaseInfos(Path file) {
-        Objects.requireNonNull(file);
         return createInfos(file, UUID.fromString(file.getParent().getFileName().toString()));
     }
 

--- a/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
+++ b/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
@@ -119,7 +119,7 @@ public class FsCaseService implements CaseService {
             CaseInfos caseInfos = getCaseInfos(file);
             return Objects.nonNull(caseInfos) ? removeGzipExtensionFromPlainFile(caseInfos) : null;
         } catch (Exception e) {
-            // This method is called by getCases() that is a method for supervision and administration. We do not want the request to stop and fail on an error cases.
+            // This method is called by getCases() that is a method for supervision and administration. We do not want the request to stop and fail on error cases.
             LOGGER.error("Error processing file {}: {}", file.getFileName(), e.getMessage(), e);
             return null;
         }

--- a/src/main/java/com/powsybl/caseserver/service/MetadataService.java
+++ b/src/main/java/com/powsybl/caseserver/service/MetadataService.java
@@ -31,7 +31,7 @@ public class MetadataService {
 
     @Transactional
     public void disableCaseExpiration(UUID caseUuid) {
-        CaseMetadataEntity caseMetadataEntity = caseMetadataRepository.findById(caseUuid).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "case " + caseUuid + NOT_FOUND));
+        CaseMetadataEntity caseMetadataEntity = caseMetadataRepository.findById(caseUuid).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Metadata of case " + caseUuid + NOT_FOUND));
         caseMetadataEntity.setExpirationDate(null);
     }
 }

--- a/src/main/java/com/powsybl/caseserver/service/S3CaseService.java
+++ b/src/main/java/com/powsybl/caseserver/service/S3CaseService.java
@@ -270,12 +270,23 @@ public class S3CaseService implements CaseService {
         List<CaseInfos> caseInfosList = new ArrayList<>();
         CaseInfos caseInfos;
         for (S3Object o : getCaseS3Objects(rootDirectory + DELIMITER)) {
-            caseInfos = getCaseInfos(parseUuidFromKey(o.key()));
+            caseInfos = getCaseInfoSafely(parseUuidFromKey(o.key()));
             if (Objects.nonNull(caseInfos)) {
                 caseInfosList.add(caseInfos);
             }
         }
         return caseInfosList;
+    }
+
+    private CaseInfos getCaseInfoSafely(UUID uuid) {
+        Objects.requireNonNull(uuid);
+        try {
+            return getCaseInfos(uuid);
+        } catch (Exception e) {
+            // This method is called by getCases() that is a method for supervision and administration. We do not want the request to stop and fail on error cases.
+            LOGGER.error("Error processing case with uuid {}: {}", uuid, e.getMessage(), e);
+            return null;
+        }
     }
 
     @Override

--- a/src/test/java/com/powsybl/caseserver/service/AbstractCaseControllerTest.java
+++ b/src/test/java/com/powsybl/caseserver/service/AbstractCaseControllerTest.java
@@ -721,14 +721,14 @@ abstract class AbstractCaseControllerTest {
         return "date:\"" + utcFormattedDate + "\"";
     }
 
-    abstract UUID addCaseWithoutMetadata() throws Exception;
-
     @Test
     void casesWithoutMetadataShouldBeIgnored() throws Exception {
         createStorageDir();
 
         // add a case file in a UUID named directory but no metadata in the database
-        UUID caseUuid = addCaseWithoutMetadata();
+        UUID caseUuid = importCase(TEST_CASE, false);
+        assertNotNull(outputDestination.receive(1000, caseImportDestination));
+        caseMetadataRepository.deleteById(caseUuid);
 
         // import a case properly
         importCase(TEST_CASE, false);

--- a/src/test/java/com/powsybl/caseserver/service/AbstractCaseControllerTest.java
+++ b/src/test/java/com/powsybl/caseserver/service/AbstractCaseControllerTest.java
@@ -57,7 +57,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @ContextConfigurationWithTestChannel
 abstract class AbstractCaseControllerTest {
-    private static final String TEST_CASE = "testCase.xiidm";
+    static final String TEST_CASE = "testCase.xiidm";
     private static final String TEST_TAR_CASE = "tarCase.tar";
     private static final String TEST_CASE_FORMAT = "XIIDM";
     private static final String NOT_A_NETWORK = "notANetwork.txt";
@@ -80,11 +80,11 @@ abstract class AbstractCaseControllerTest {
     OutputDestination outputDestination;
 
     @Autowired
-    private ObjectMapper mapper;
+    ObjectMapper mapper;
 
     FileSystem fileSystem;
 
-    private final String caseImportDestination = "case.import.destination";
+    final String caseImportDestination = "case.import.destination";
 
     @AfterEach
     public void tearDown() throws Exception {
@@ -93,7 +93,7 @@ abstract class AbstractCaseControllerTest {
         TestUtils.assertQueuesEmptyThenClear(destinations, outputDestination);
     }
 
-    private void createStorageDir() throws IOException {
+    void createStorageDir() throws IOException {
         Path path = fileSystem.getPath(caseService.getRootDirectory());
         if (!Files.exists(path)) {
             Files.createDirectories(path);
@@ -467,7 +467,7 @@ abstract class AbstractCaseControllerTest {
         assertFalse(caseMetadataRepository.findById(duplicateCaseUuid).get().isIndexed());
     }
 
-    private UUID importCase(String testCase, Boolean withExpiration) throws Exception {
+    UUID importCase(String testCase, Boolean withExpiration) throws Exception {
         String importedCase;
         if (withExpiration) {
             importedCase = mvc.perform(multipart("/v1/cases")
@@ -721,20 +721,16 @@ abstract class AbstractCaseControllerTest {
         return "date:\"" + utcFormattedDate + "\"";
     }
 
+    abstract UUID addCaseWithoutMetadata() throws Exception;
+
     @Test
-    void invalidFileInCaseDirectoryShouldBeIgnored() throws Exception {
+    void casesWithoutMetadataShouldBeIgnored() throws Exception {
         createStorageDir();
 
-        // add a random file in the storage, not stored in a UUID named directory
-        Path filePath = fileSystem.getPath(caseService.getRootDirectory()).resolve("randomFile.txt");
-        Files.createFile(filePath);
-
         // add a case file in a UUID named directory but no metadata in the database
-        Path casePath = fileSystem.getPath(caseService.getRootDirectory()).resolve(UUID.randomUUID().toString());
-        Files.createDirectory(casePath);
-        Files.write(casePath.resolve(TEST_CASE), AbstractCaseControllerTest.class.getResourceAsStream("/" + TEST_CASE).readAllBytes());
+        UUID caseUuid = addCaseWithoutMetadata();
 
-        // import case properly
+        // import a case properly
         importCase(TEST_CASE, false);
 
         MvcResult mvcResult = mvc.perform(get("/v1/cases"))
@@ -745,7 +741,7 @@ abstract class AbstractCaseControllerTest {
         assertEquals(1, caseInfos.size());
         assertEquals(TEST_CASE, caseInfos.get(0).getName());
 
-        Files.delete(filePath);
+        caseService.deleteCase(caseUuid);
         mvc.perform(delete("/v1/cases"))
                 .andExpect(status().isOk());
         assertNotNull(outputDestination.receive(1000, caseImportDestination));

--- a/src/test/java/com/powsybl/caseserver/service/AbstractCaseControllerTest.java
+++ b/src/test/java/com/powsybl/caseserver/service/AbstractCaseControllerTest.java
@@ -724,8 +724,16 @@ abstract class AbstractCaseControllerTest {
     @Test
     void invalidFileInCaseDirectoryShouldBeIgnored() throws Exception {
         createStorageDir();
+
+        // add a random file in the storage, not store in a UUID named directory
         Path filePath = fileSystem.getPath(caseService.getRootDirectory()).resolve("randomFile.txt");
         Files.createFile(filePath);
+
+        // add a case in the storage but no metadata in the database
+        Path casePath = fileSystem.getPath(caseService.getRootDirectory()).resolve(UUID.randomUUID().toString());
+        Files.createDirectory(casePath);
+        Files.createFile(casePath.resolve(TEST_CASE));
+
         importCase(TEST_CASE, false);
 
         MvcResult mvcResult = mvc.perform(get("/v1/cases"))

--- a/src/test/java/com/powsybl/caseserver/service/AbstractCaseControllerTest.java
+++ b/src/test/java/com/powsybl/caseserver/service/AbstractCaseControllerTest.java
@@ -725,11 +725,11 @@ abstract class AbstractCaseControllerTest {
     void invalidFileInCaseDirectoryShouldBeIgnored() throws Exception {
         createStorageDir();
 
-        // add a random file in the storage, not store in a UUID named directory
+        // add a random file in the storage, not stored in a UUID named directory
         Path filePath = fileSystem.getPath(caseService.getRootDirectory()).resolve("randomFile.txt");
         Files.createFile(filePath);
 
-        // add a case in the storage but no metadata in the database
+        // add a case file in a UUID named directory but no metadata in the database
         Path casePath = fileSystem.getPath(caseService.getRootDirectory()).resolve(UUID.randomUUID().toString());
         Files.createDirectory(casePath);
         Files.createFile(casePath.resolve(TEST_CASE));

--- a/src/test/java/com/powsybl/caseserver/service/AbstractCaseControllerTest.java
+++ b/src/test/java/com/powsybl/caseserver/service/AbstractCaseControllerTest.java
@@ -732,8 +732,9 @@ abstract class AbstractCaseControllerTest {
         // add a case file in a UUID named directory but no metadata in the database
         Path casePath = fileSystem.getPath(caseService.getRootDirectory()).resolve(UUID.randomUUID().toString());
         Files.createDirectory(casePath);
-        Files.createFile(casePath.resolve(TEST_CASE));
+        Files.write(casePath.resolve(TEST_CASE), AbstractCaseControllerTest.class.getResourceAsStream("/" + TEST_CASE).readAllBytes());
 
+        // import case properly
         importCase(TEST_CASE, false);
 
         MvcResult mvcResult = mvc.perform(get("/v1/cases"))

--- a/src/test/java/com/powsybl/caseserver/service/AbstractCaseControllerTest.java
+++ b/src/test/java/com/powsybl/caseserver/service/AbstractCaseControllerTest.java
@@ -732,6 +732,7 @@ abstract class AbstractCaseControllerTest {
 
         // import a case properly
         importCase(TEST_CASE, false);
+        assertNotNull(outputDestination.receive(1000, caseImportDestination));
 
         MvcResult mvcResult = mvc.perform(get("/v1/cases"))
                 .andExpect(status().isOk())
@@ -744,7 +745,6 @@ abstract class AbstractCaseControllerTest {
         caseService.deleteCase(caseUuid);
         mvc.perform(delete("/v1/cases"))
                 .andExpect(status().isOk());
-        assertNotNull(outputDestination.receive(1000, caseImportDestination));
     }
 
     @Test

--- a/src/test/java/com/powsybl/caseserver/service/FsCaseControllerTest.java
+++ b/src/test/java/com/powsybl/caseserver/service/FsCaseControllerTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.caseserver.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,7 +42,7 @@ class FsCaseControllerTest extends AbstractCaseControllerTest {
     @BeforeEach
     void setUp() {
         caseService = fsCaseService;
-        fileSystem = Jimfs.newFileSystem();
+        fileSystem = Jimfs.newFileSystem(Configuration.unix());
         ((FsCaseService) caseService).setFileSystem(fileSystem);
         caseService.setComputationManager(Mockito.mock(ComputationManager.class));
         caseMetadataRepository.deleteAll();

--- a/src/test/java/com/powsybl/caseserver/service/FsCaseControllerTest.java
+++ b/src/test/java/com/powsybl/caseserver/service/FsCaseControllerTest.java
@@ -28,7 +28,6 @@ import org.springframework.test.web.servlet.MvcResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.UUID;
 
 /**
  * @author Ghazwa Rehili <ghazwa.rehili at rte-france.com>
@@ -78,14 +77,5 @@ class FsCaseControllerTest extends AbstractCaseControllerTest {
         mvc.perform(delete("/v1/cases"))
                 .andExpect(status().isOk());
         assertNotNull(outputDestination.receive(1000, caseImportDestination));
-    }
-
-    @Override
-    UUID addCaseWithoutMetadata() throws Exception {
-        UUID caseUuid = UUID.randomUUID();
-        Path casePath = fileSystem.getPath(caseService.getRootDirectory()).resolve(caseUuid.toString());
-        Files.createDirectory(casePath);
-        Files.write(casePath.resolve(TEST_CASE), AbstractCaseControllerTest.class.getResourceAsStream("/" + TEST_CASE).readAllBytes());
-        return caseUuid;
     }
 }

--- a/src/test/java/com/powsybl/caseserver/service/FsCaseControllerTest.java
+++ b/src/test/java/com/powsybl/caseserver/service/FsCaseControllerTest.java
@@ -6,18 +6,28 @@
  */
 package com.powsybl.caseserver.service;
 
-import com.google.common.jimfs.Configuration;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.jimfs.Jimfs;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.powsybl.caseserver.dto.CaseInfos;
 import com.powsybl.computation.ComputationManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
 
 /**
  * @author Ghazwa Rehili <ghazwa.rehili at rte-france.com>
@@ -31,7 +41,7 @@ class FsCaseControllerTest extends AbstractCaseControllerTest {
     @BeforeEach
     void setUp() {
         caseService = fsCaseService;
-        fileSystem = Jimfs.newFileSystem(Configuration.unix());
+        fileSystem = Jimfs.newFileSystem();
         ((FsCaseService) caseService).setFileSystem(fileSystem);
         caseService.setComputationManager(Mockito.mock(ComputationManager.class));
         caseMetadataRepository.deleteAll();
@@ -44,4 +54,37 @@ class FsCaseControllerTest extends AbstractCaseControllerTest {
         mvc.perform(delete("/v1/cases")).andExpect(status().isUnprocessableEntity());
     }
 
+    @Test
+    void invalidFileInCaseDirectoryShouldBeIgnored() throws Exception {
+        createStorageDir();
+
+        // add a random file in the storage, not stored in a UUID named directory
+        Path filePath = fileSystem.getPath(caseService.getRootDirectory()).resolve("randomFile.txt");
+        Files.createFile(filePath);
+
+        // import a case properly
+        importCase(TEST_CASE, false);
+
+        MvcResult mvcResult = mvc.perform(get("/v1/cases"))
+                .andExpect(status().isOk())
+                .andReturn();
+        String resultAsString = mvcResult.getResponse().getContentAsString();
+        List<CaseInfos> caseInfos = mapper.readValue(resultAsString, new TypeReference<>() { });
+        assertEquals(1, caseInfos.size());
+        assertEquals(TEST_CASE, caseInfos.get(0).getName());
+
+        Files.delete(filePath);
+        mvc.perform(delete("/v1/cases"))
+                .andExpect(status().isOk());
+        assertNotNull(outputDestination.receive(1000, caseImportDestination));
+    }
+
+    @Override
+    UUID addCaseWithoutMetadata() throws Exception {
+        UUID caseUuid = UUID.randomUUID();
+        Path casePath = fileSystem.getPath(caseService.getRootDirectory()).resolve(caseUuid.toString());
+        Files.createDirectory(casePath);
+        Files.write(casePath.resolve(TEST_CASE), AbstractCaseControllerTest.class.getResourceAsStream("/" + TEST_CASE).readAllBytes());
+        return caseUuid;
+    }
 }

--- a/src/test/java/com/powsybl/caseserver/service/S3CaseControllerTest.java
+++ b/src/test/java/com/powsybl/caseserver/service/S3CaseControllerTest.java
@@ -14,6 +14,8 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 
+import java.util.UUID;
+
 /**
  * @author Ghazwa Rehili <ghazwa.rehili at rte-france.com>
  */
@@ -30,5 +32,12 @@ class S3CaseControllerTest extends AbstractCaseControllerTest implements MinioCo
         caseService.setComputationManager(Mockito.mock(ComputationManager.class));
         caseService.deleteAllCases();
         outputDestination.clear();
+    }
+
+    @Override
+    UUID addCaseWithoutMetadata() throws Exception {
+        UUID caseUuid = importCase(TEST_CASE, false);
+        caseMetadataRepository.deleteById(caseUuid);
+        return caseUuid;
     }
 }

--- a/src/test/java/com/powsybl/caseserver/service/S3CaseControllerTest.java
+++ b/src/test/java/com/powsybl/caseserver/service/S3CaseControllerTest.java
@@ -14,10 +14,6 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 /**
  * @author Ghazwa Rehili <ghazwa.rehili at rte-france.com>
  */
@@ -34,13 +30,5 @@ class S3CaseControllerTest extends AbstractCaseControllerTest implements MinioCo
         caseService.setComputationManager(Mockito.mock(ComputationManager.class));
         caseService.deleteAllCases();
         outputDestination.clear();
-    }
-
-    @Override
-    UUID addCaseWithoutMetadata() throws Exception {
-        UUID caseUuid = importCase(TEST_CASE, false);
-        assertNotNull(outputDestination.receive(1000, caseImportDestination));
-        caseMetadataRepository.deleteById(caseUuid);
-        return caseUuid;
     }
 }

--- a/src/test/java/com/powsybl/caseserver/service/S3CaseControllerTest.java
+++ b/src/test/java/com/powsybl/caseserver/service/S3CaseControllerTest.java
@@ -16,6 +16,8 @@ import org.springframework.test.context.TestPropertySource;
 
 import java.util.UUID;
 
+import static org.junit.Assert.assertNotNull;
+
 /**
  * @author Ghazwa Rehili <ghazwa.rehili at rte-france.com>
  */
@@ -37,6 +39,7 @@ class S3CaseControllerTest extends AbstractCaseControllerTest implements MinioCo
     @Override
     UUID addCaseWithoutMetadata() throws Exception {
         UUID caseUuid = importCase(TEST_CASE, false);
+        assertNotNull(outputDestination.receive(1000, caseImportDestination));
         caseMetadataRepository.deleteById(caseUuid);
         return caseUuid;
     }

--- a/src/test/java/com/powsybl/caseserver/service/S3CaseControllerTest.java
+++ b/src/test/java/com/powsybl/caseserver/service/S3CaseControllerTest.java
@@ -16,7 +16,7 @@ import org.springframework.test.context.TestPropertySource;
 
 import java.util.UUID;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author Ghazwa Rehili <ghazwa.rehili at rte-france.com>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
Changes the behavior of the getCases() method

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No

**What is the current behavior?**
While executing getCases(), if a case is present on the filesystem but not referenced in the case_metadata database, the method throws an exception and returns a 404.



**What is the new behavior (if this is a feature change)?**
In such a case, getCases() will return the cases list without the cases non present in the case_metadata db. The error will be logged.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

