### PR TITLE
Reduce memory footprint of getInputStream

### DIFF
--- a/src/main/java/com/powsybl/caseserver/CaseController.java
+++ b/src/main/java/com/powsybl/caseserver/CaseController.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -110,7 +111,7 @@ public class CaseController {
 
     @GetMapping(value = "/cases/{caseUuid}")
     @Operation(summary = "Download a case")
-    public ResponseEntity<InputStreamResource> downloadCase(@PathVariable("caseUuid") UUID caseUuid) {
+    public ResponseEntity<Resource> downloadCase(@PathVariable("caseUuid") UUID caseUuid) {
         LOGGER.debug("getCase request received with parameter caseUuid = {}", caseUuid);
         Optional<InputStream> caseStreamOpt = caseService.getCaseStream(caseUuid);
         if (caseStreamOpt.isEmpty()) {

--- a/src/main/java/com/powsybl/caseserver/CaseException.java
+++ b/src/main/java/com/powsybl/caseserver/CaseException.java
@@ -50,7 +50,7 @@ public final class CaseException extends RuntimeException {
         return type;
     }
 
-    public static CaseException createDirectoryAreadyExists(String directory) {
+    public static CaseException createDirectoryAlreadyExists(String directory) {
         Objects.requireNonNull(directory);
         return new CaseException(Type.DIRECTORY_ALREADY_EXISTS, "A directory with the same name already exists: " + directory);
     }
@@ -100,7 +100,7 @@ public final class CaseException extends RuntimeException {
         return new CaseException(Type.TEMP_DIRECTORY_CREATION, "Error creating temporary directory: " + uuid, e);
     }
 
-    public static CaseException createUInitTempFileError(UUID uuid, Throwable e) {
+    public static CaseException createInitTempFileError(UUID uuid, Throwable e) {
         Objects.requireNonNull(uuid);
         return new CaseException(Type.TEMP_FILE_INIT, "Error initializing temporary case file: " + uuid, e);
     }

--- a/src/main/java/com/powsybl/caseserver/Utils.java
+++ b/src/main/java/com/powsybl/caseserver/Utils.java
@@ -6,12 +6,7 @@
  */
 package com.powsybl.caseserver;
 
-import org.apache.commons.io.IOUtils;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.util.List;
-import java.util.zip.GZIPInputStream;
 
 /**
  * @author Etienne Lesot <etienne.lesot at rte-france.com>
@@ -50,10 +45,5 @@ public final class Utils {
 
     public static boolean isTaredFile(String caseName) {
         return caseName.endsWith(".tar");
-    }
-
-    public static byte[] decompress(byte[] data) throws IOException {
-        GZIPInputStream gzipInputStream = new GZIPInputStream(new ByteArrayInputStream(data));
-        return IOUtils.toByteArray(gzipInputStream);
     }
 }

--- a/src/main/java/com/powsybl/caseserver/datasource/CaseDataSourceController.java
+++ b/src/main/java/com/powsybl/caseserver/datasource/CaseDataSourceController.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -63,16 +64,16 @@ public class CaseDataSourceController {
 
     @GetMapping(value = "/cases/{caseUuid}/datasource", params = {"suffix", "ext"})
     @Operation(summary = "Get an input stream")
-    public ResponseEntity<InputStreamResource> getFileData(@PathVariable("caseUuid") UUID caseUuid,
-                                                      @RequestParam(value = "suffix") String suffix,
-                                                      @RequestParam(value = "ext") String ext) {
+    public ResponseEntity<Resource> getFileData(@PathVariable("caseUuid") UUID caseUuid,
+                                                @RequestParam(value = "suffix") String suffix,
+                                                @RequestParam(value = "ext") String ext) {
         InputStream inputStream = caseDataSourceService.getInputStream(caseUuid, suffix, ext);
         return ResponseEntity.ok().contentType(new MediaType("text", "plain", StandardCharsets.UTF_8)).body(new InputStreamResource(inputStream));
     }
 
     @GetMapping(value = "/cases/{caseUuid}/datasource", params = "fileName")
     @Operation(summary = "Get an input stream")
-    public ResponseEntity<InputStreamResource> getFileData(@PathVariable("caseUuid") UUID caseUuid,
+    public ResponseEntity<Resource> getFileData(@PathVariable("caseUuid") UUID caseUuid,
                                                              @RequestParam(value = "fileName") String fileName) {
         InputStream inputStream = caseDataSourceService.getInputStream(caseUuid, fileName);
         return ResponseEntity.ok().contentType(new MediaType("text", "plain", StandardCharsets.UTF_8)).body(new InputStreamResource(inputStream));

--- a/src/main/java/com/powsybl/caseserver/datasource/CaseDataSourceController.java
+++ b/src/main/java/com/powsybl/caseserver/datasource/CaseDataSourceController.java
@@ -17,7 +17,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
@@ -65,26 +64,18 @@ public class CaseDataSourceController {
     @GetMapping(value = "/cases/{caseUuid}/datasource", params = {"suffix", "ext"})
     @Operation(summary = "Get an input stream")
     public ResponseEntity<InputStreamResource> getFileData(@PathVariable("caseUuid") UUID caseUuid,
-                                                           @RequestParam(value = "suffix") String suffix,
-                                                           @RequestParam(value = "ext") String ext) {
-        try {
-            InputStream byteArray = caseDataSourceService.getInputStream(caseUuid, suffix, ext);
-            return ResponseEntity.ok().contentType(new MediaType("text", "plain", StandardCharsets.UTF_8)).body(new InputStreamResource(byteArray));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+                                                      @RequestParam(value = "suffix") String suffix,
+                                                      @RequestParam(value = "ext") String ext) {
+        InputStream inputStream = caseDataSourceService.getInputStream(caseUuid, suffix, ext);
+        return ResponseEntity.ok().contentType(new MediaType("text", "plain", StandardCharsets.UTF_8)).body(new InputStreamResource(inputStream));
     }
 
     @GetMapping(value = "/cases/{caseUuid}/datasource", params = "fileName")
     @Operation(summary = "Get an input stream")
     public ResponseEntity<InputStreamResource> getFileData(@PathVariable("caseUuid") UUID caseUuid,
                                                              @RequestParam(value = "fileName") String fileName) {
-        try {
-            InputStream byteArray = caseDataSourceService.getInputStream(caseUuid, fileName);
-            return ResponseEntity.ok().contentType(new MediaType("text", "plain", StandardCharsets.UTF_8)).body(new InputStreamResource(byteArray));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        InputStream inputStream = caseDataSourceService.getInputStream(caseUuid, fileName);
+        return ResponseEntity.ok().contentType(new MediaType("text", "plain", StandardCharsets.UTF_8)).body(new InputStreamResource(inputStream));
     }
 
     @GetMapping(value = "/cases/{caseUuid}/datasource/list")

--- a/src/main/java/com/powsybl/caseserver/datasource/CaseDataSourceController.java
+++ b/src/main/java/com/powsybl/caseserver/datasource/CaseDataSourceController.java
@@ -12,10 +12,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import java.util.UUID;
@@ -61,19 +64,27 @@ public class CaseDataSourceController {
 
     @GetMapping(value = "/cases/{caseUuid}/datasource", params = {"suffix", "ext"})
     @Operation(summary = "Get an input stream")
-    public ResponseEntity<byte[]> getFileData(@PathVariable("caseUuid") UUID caseUuid,
-                                                      @RequestParam(value = "suffix") String suffix,
-                                                      @RequestParam(value = "ext") String ext) {
-        byte[] byteArray = caseDataSourceService.getInputStream(caseUuid, suffix, ext);
-        return ResponseEntity.ok().contentType(new MediaType("text", "plain", StandardCharsets.UTF_8)).body(byteArray);
+    public ResponseEntity<InputStreamResource> getFileData(@PathVariable("caseUuid") UUID caseUuid,
+                                                           @RequestParam(value = "suffix") String suffix,
+                                                           @RequestParam(value = "ext") String ext) {
+        try {
+            InputStream byteArray = caseDataSourceService.getInputStream(caseUuid, suffix, ext);
+            return ResponseEntity.ok().contentType(new MediaType("text", "plain", StandardCharsets.UTF_8)).body(new InputStreamResource(byteArray));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @GetMapping(value = "/cases/{caseUuid}/datasource", params = "fileName")
     @Operation(summary = "Get an input stream")
-    public ResponseEntity<byte[]> getFileData(@PathVariable("caseUuid") UUID caseUuid,
+    public ResponseEntity<InputStreamResource> getFileData(@PathVariable("caseUuid") UUID caseUuid,
                                                              @RequestParam(value = "fileName") String fileName) {
-        byte[] byteArray = caseDataSourceService.getInputStream(caseUuid, fileName);
-        return ResponseEntity.ok().contentType(new MediaType("text", "plain", StandardCharsets.UTF_8)).body(byteArray);
+        try {
+            InputStream byteArray = caseDataSourceService.getInputStream(caseUuid, fileName);
+            return ResponseEntity.ok().contentType(new MediaType("text", "plain", StandardCharsets.UTF_8)).body(new InputStreamResource(byteArray));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @GetMapping(value = "/cases/{caseUuid}/datasource/list")

--- a/src/main/java/com/powsybl/caseserver/datasource/CaseDataSourceService.java
+++ b/src/main/java/com/powsybl/caseserver/datasource/CaseDataSourceService.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.caseserver.datasource;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Set;
 import java.util.UUID;
@@ -21,9 +20,9 @@ public interface CaseDataSourceService {
 
     Boolean datasourceExists(UUID caseUuid, String fileName);
 
-    InputStream getInputStream(UUID caseUuid, String suffix, String ext) throws IOException;
+    InputStream getInputStream(UUID caseUuid, String suffix, String ext);
 
-    InputStream getInputStream(UUID caseUuid, String fileName) throws IOException;
+    InputStream getInputStream(UUID caseUuid, String fileName);
 
     Set<String> listName(UUID caseUuid, String regex);
 

--- a/src/main/java/com/powsybl/caseserver/datasource/CaseDataSourceService.java
+++ b/src/main/java/com/powsybl/caseserver/datasource/CaseDataSourceService.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.caseserver.datasource;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Set;
 import java.util.UUID;
 
@@ -19,9 +21,9 @@ public interface CaseDataSourceService {
 
     Boolean datasourceExists(UUID caseUuid, String fileName);
 
-    byte[] getInputStream(UUID caseUuid, String suffix, String ext);
+    InputStream getInputStream(UUID caseUuid, String suffix, String ext) throws IOException;
 
-    byte[] getInputStream(UUID caseUuid, String fileName);
+    InputStream getInputStream(UUID caseUuid, String fileName) throws IOException;
 
     Set<String> listName(UUID caseUuid, String regex);
 

--- a/src/main/java/com/powsybl/caseserver/datasource/FsCaseDataSourceService.java
+++ b/src/main/java/com/powsybl/caseserver/datasource/FsCaseDataSourceService.java
@@ -9,7 +9,6 @@ package com.powsybl.caseserver.datasource;
 import com.powsybl.caseserver.service.CaseService;
 import com.powsybl.caseserver.service.FsCaseService;
 import com.powsybl.commons.datasource.DataSource;
-import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.stereotype.Service;
@@ -61,23 +60,15 @@ public class FsCaseDataSourceService implements CaseDataSourceService {
     }
 
     @Override
-    public byte[] getInputStream(UUID caseUuid, String fileName) {
+    public InputStream getInputStream(UUID caseUuid, String fileName) throws IOException {
         DataSource dataSource = getDatasource(caseUuid);
-        try (InputStream inputStream = dataSource.newInputStream(fileName)) {
-            return IOUtils.toByteArray(inputStream);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return dataSource.newInputStream(fileName);
     }
 
     @Override
-    public byte[] getInputStream(UUID caseUuid, String suffix, String ext) {
+    public InputStream getInputStream(UUID caseUuid, String suffix, String ext) throws IOException {
         DataSource dataSource = getDatasource(caseUuid);
-        try (InputStream inputStream = dataSource.newInputStream(suffix, ext)) {
-            return IOUtils.toByteArray(inputStream);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return dataSource.newInputStream(suffix, ext);
     }
 
     @Override

--- a/src/main/java/com/powsybl/caseserver/datasource/FsCaseDataSourceService.java
+++ b/src/main/java/com/powsybl/caseserver/datasource/FsCaseDataSourceService.java
@@ -60,15 +60,23 @@ public class FsCaseDataSourceService implements CaseDataSourceService {
     }
 
     @Override
-    public InputStream getInputStream(UUID caseUuid, String fileName) throws IOException {
+    public InputStream getInputStream(UUID caseUuid, String fileName) {
         DataSource dataSource = getDatasource(caseUuid);
-        return dataSource.newInputStream(fileName);
+        try {
+            return dataSource.newInputStream(fileName);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @Override
-    public InputStream getInputStream(UUID caseUuid, String suffix, String ext) throws IOException {
+    public InputStream getInputStream(UUID caseUuid, String suffix, String ext) {
         DataSource dataSource = getDatasource(caseUuid);
-        return dataSource.newInputStream(suffix, ext);
+        try {
+            return dataSource.newInputStream(suffix, ext);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @Override

--- a/src/main/java/com/powsybl/caseserver/datasource/S3CaseDataSourceService.java
+++ b/src/main/java/com/powsybl/caseserver/datasource/S3CaseDataSourceService.java
@@ -10,11 +10,13 @@ import com.powsybl.caseserver.service.CaseService;
 import com.powsybl.caseserver.service.S3CaseService;
 import com.powsybl.commons.datasource.DataSource;
 import com.powsybl.commons.datasource.DataSourceUtil;
-import org.apache.commons.io.IOUtils;
+import org.apache.commons.compress.utils.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.Set;
 import java.util.UUID;
@@ -48,27 +50,13 @@ public class S3CaseDataSourceService implements CaseDataSourceService {
     }
 
     @Override
-    public byte[] getInputStream(UUID caseUuid, String fileName) {
-        String caseName = s3CaseService.getCaseName(caseUuid);
-        String caseFileKey;
-        // For archived cases (.zip, .tar, ...), individual files are gzipped in S3 server.
-        // Here the requested file is decompressed and simply returned.
-        if (isArchivedCaseFile(caseName)) {
-            caseFileKey = s3CaseService.uuidToKeyWithFileName(caseUuid, fileName + GZIP_EXTENSION);
-            return s3CaseService.withS3DownloadedTempPath(caseUuid, caseFileKey,
-                    file -> decompress(Files.readAllBytes(file)));
-        } else {
-            if (Boolean.TRUE.equals(s3CaseService.isUploadedAsPlainFile(caseUuid))) {
-                caseName += GZIP_EXTENSION;
-            }
-            caseFileKey = s3CaseService.uuidToKeyWithFileName(caseUuid, caseName);
-            return s3CaseService.withS3DownloadedTempPath(caseUuid, caseFileKey,
-                    casePath -> IOUtils.toByteArray(DataSource.fromPath(casePath).newInputStream(fileName)));
-        }
+    public InputStream getInputStream(UUID caseUuid, String fileName) {
+        //FIXME: to do for S3
+        return null;
     }
 
     @Override
-    public byte[] getInputStream(UUID caseUuid, String suffix, String ext) {
+    public InputStream getInputStream(UUID caseUuid, String suffix, String ext) {
         return getInputStream(caseUuid, DataSourceUtil.getFileName(getBaseName(caseUuid), suffix, ext));
     }
 

--- a/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
+++ b/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
@@ -194,7 +194,7 @@ public class FsCaseService implements CaseService {
         validateCaseName(caseName);
 
         if (Files.exists(uuidDirectory)) {
-            throw CaseException.createDirectoryAreadyExists(uuidDirectory.toString());
+            throw CaseException.createDirectoryAlreadyExists(uuidDirectory.toString());
         }
 
         Path caseFile;

--- a/src/main/java/com/powsybl/caseserver/service/S3CaseService.java
+++ b/src/main/java/com/powsybl/caseserver/service/S3CaseService.java
@@ -130,7 +130,7 @@ public class S3CaseService implements CaseService {
             try {
                 contentInitializer.accept(tempCasePath);
             } catch (Exception e) {
-                throw CaseException.createUInitTempFileError(caseUuid, e);
+                throw CaseException.createInitTempFileError(caseUuid, e);
             }
             // after this line, need to cleanup the file
             try {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
It uses stream to supply an input stream in getInputStream instead of storing the byte array in memory.

**What is the current behavior?**
<!-- You can also link to an open issue here -->
The full byte array is loaded into memory and then streamed.


**What is the new behavior (if this is a feature change)?**
The file is streamed instead.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
The client can also use the stream directly, I did some adaptations in https://github.com/powsybl/powsybl-case-datasource/pull/150. This PR is independent of the other and can be merged before.