### PR TITLE
Fiximportplainfiles s3withfolders

### DIFF
--- a/src/main/java/com/powsybl/caseserver/service/S3CaseService.java
+++ b/src/main/java/com/powsybl/caseserver/service/S3CaseService.java
@@ -304,16 +304,15 @@ public class S3CaseService implements CaseService {
     }
 
     public Boolean datasourceExists(UUID caseUuid, String fileName) {
-        if (getCaseS3Objects(caseUuid).size() > 1 && fileName.equals(getCaseName(caseUuid))) {
-            return Boolean.FALSE;
-        }
-
         String key = uuidToKeyWithFileName(caseUuid, fileName);
         String caseName = getCaseName(caseUuid);
         // For compressed cases, we append the compression extension to the case name as only the compressed file is stored in S3.
         // i.e. : Assuming test.xml.gz is stored in S3. When you request datasourceExists(randomUUID, "test.xml"), you ask to S3 API ("test.xml" + ".gz") exists ? => true
         if (isCompressedCaseFile(caseName)) {
             key = key + "." + getCompressionFormat(caseUuid);
+        } else if (isArchivedCaseFile(caseName) && fileName.equals(getCaseName(caseUuid))) {
+            // We store the archive in addition to its content files, so exists when matching the archive name should return false
+            return Boolean.FALSE;
         } else if (isArchivedCaseFile(caseName) || Boolean.TRUE.equals(isUploadedAsPlainFile(caseUuid))) {
             key = key + GZIP_EXTENSION;
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
NO


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->
Error when creating a study from a plain file. "No Importer Found"


**What is the new behavior (if this is a feature change)?**
No Error


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
exists(suffix) returns false when an s3 implementation force creates intermediate directories because the code for archives is triggerd
same fix as https://github.com/powsybl/powsybl-case-server/commit/2b051e6ec#diff-b658657cc58e2c9c705a5e9061e303c05b04d661eaf5500524e52df611af2916L324