### PR TITLE
Recreate index instead of deleting all its documents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <artifactId>powsybl-case-server</artifactId>
     <name>Case server</name>
-    <version>2.14.0-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/src/main/java/com/powsybl/caseserver/SupervisionController.java
+++ b/src/main/java/com/powsybl/caseserver/SupervisionController.java
@@ -68,11 +68,15 @@ public class SupervisionController {
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping(value = "/cases/indexation")
-    @Operation(summary = "delete indexed cases")
-    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "all indexed cases have been deleted")})
-    public ResponseEntity<String> deleteIndexedCases() {
-        return ResponseEntity.ok().contentType(MediaType.TEXT_PLAIN).body(Long.toString(supervisionService.deleteIndexedCases()));
+    @PostMapping(value = "/cases/index/recreate")
+    @Operation(summary = "Recreate Elasticsearch index")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Elasticsearch index recreated successfully"),
+        @ApiResponse(responseCode = "500", description = "Failed to recreate Elasticsearch index")
+    })
+    public ResponseEntity<Void> recreateESIndex() {
+        supervisionService.recreateIndex();
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping(value = "/cases/indexation-count")

--- a/src/main/java/com/powsybl/caseserver/SupervisionController.java
+++ b/src/main/java/com/powsybl/caseserver/SupervisionController.java
@@ -68,7 +68,7 @@ public class SupervisionController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping(value = "/cases/index/recreate")
+    @PostMapping(value = "/cases/index")
     @Operation(summary = "Recreate Elasticsearch index")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Elasticsearch index recreated successfully"),

--- a/src/main/java/com/powsybl/caseserver/service/SupervisionService.java
+++ b/src/main/java/com/powsybl/caseserver/service/SupervisionService.java
@@ -9,6 +9,7 @@ package com.powsybl.caseserver.service;
 import com.powsybl.caseserver.dto.CaseInfos;
 import com.powsybl.caseserver.elasticsearch.CaseInfosRepository;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -32,16 +33,17 @@ public class SupervisionService {
     }
 
     public void recreateIndex() {
-        boolean deleted = elasticsearchOperations.indexOps(CaseInfos.class).delete();
-        if (!deleted) {
+        IndexOperations indexOperations = elasticsearchOperations.indexOps(CaseInfos.class);
+        boolean isDeleted = indexOperations.delete();
+        if (!isDeleted) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-                    "Failed to delete Elasticsearch index.");
+                    "Failed to delete cases ElasticSearch index");
         }
 
-        boolean created = elasticsearchOperations.indexOps(CaseInfos.class).createWithMapping();
-        if (!created) {
+        boolean isCreated = indexOperations.createWithMapping();
+        if (!isCreated) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-                    "Failed to create Elasticsearch index.");
+                    "Failed to create cases ElasticSearch index");
         }
     }
 }

--- a/src/test/java/com/powsybl/caseserver/AbstractSupervisionControllerTest.java
+++ b/src/test/java/com/powsybl/caseserver/AbstractSupervisionControllerTest.java
@@ -63,7 +63,8 @@ abstract class AbstractSupervisionControllerTest {
         importCase(true);
         importCase(false);
 
-        mockMvc.perform(delete("/v1/supervision/cases/indexation"))
+        // recreate the index
+        mockMvc.perform(post("/v1/supervision/cases/index/recreate"))
                 .andExpect(status().isOk());
 
         assertEquals(0, supervisionService.getIndexedCasesCount());

--- a/src/test/java/com/powsybl/caseserver/AbstractSupervisionControllerTest.java
+++ b/src/test/java/com/powsybl/caseserver/AbstractSupervisionControllerTest.java
@@ -64,7 +64,7 @@ abstract class AbstractSupervisionControllerTest {
         importCase(false);
 
         // recreate the index
-        mockMvc.perform(post("/v1/supervision/cases/index/recreate"))
+        mockMvc.perform(post("/v1/supervision/cases/index"))
                 .andExpect(status().isOk());
 
         assertEquals(0, supervisionService.getIndexedCasesCount());

--- a/src/test/java/com/powsybl/caseserver/service/SupervisionServiceTest.java
+++ b/src/test/java/com/powsybl/caseserver/service/SupervisionServiceTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.caseserver.service;
+
+import com.powsybl.caseserver.dto.CaseInfos;
+import com.powsybl.caseserver.elasticsearch.DisableElasticsearch;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+/**
+ * @author Antoine Bouhours <antoine.bouhours at rte-france.com>
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@DisableElasticsearch
+class SupervisionServiceTest {
+
+    @MockBean
+    ElasticsearchOperations elasticsearchOperations;
+
+    @MockBean
+    IndexOperations indexOperations;
+
+    @Autowired
+    SupervisionService supervisionService;
+
+    @Test
+    void recreateIndexThrowsExceptionWhenDeleteFails() {
+        when(elasticsearchOperations.indexOps(CaseInfos.class)).thenReturn(indexOperations);
+        when(indexOperations.delete()).thenReturn(false);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> supervisionService.recreateIndex());
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getStatusCode());
+        assertEquals("Failed to delete cases ElasticSearch index", exception.getReason());
+        verify(elasticsearchOperations, times(1)).indexOps(CaseInfos.class);
+        verify(indexOperations, times(1)).delete();
+        verify(indexOperations, never()).createWithMapping();
+    }
+
+    @Test
+    void recreateIndexThrowsExceptionWhenCreateFails() {
+        when(elasticsearchOperations.indexOps(CaseInfos.class)).thenReturn(indexOperations);
+        when(indexOperations.delete()).thenReturn(true);
+        when(indexOperations.createWithMapping()).thenReturn(false);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> supervisionService.recreateIndex());
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getStatusCode());
+        assertEquals("Failed to create cases ElasticSearch index", exception.getReason());
+        verify(elasticsearchOperations, times(1)).indexOps(CaseInfos.class);
+        verify(indexOperations, times(1)).delete();
+        verify(indexOperations, times(1)).createWithMapping();
+    }
+
+    @Test
+    void recreateIndexSuccess() {
+        when(elasticsearchOperations.indexOps(CaseInfos.class)).thenReturn(indexOperations);
+        when(indexOperations.delete()).thenReturn(true);
+        when(indexOperations.createWithMapping()).thenReturn(true);
+
+        supervisionService.recreateIndex();
+
+        verify(elasticsearchOperations, times(1)).indexOps(CaseInfos.class);
+        verify(indexOperations, times(1)).delete();
+        verify(indexOperations, times(1)).createWithMapping();
+    }
+
+    @AfterEach
+    void verifyNoMoreInteractionsMocks() {
+        verifyNoMoreInteractions(elasticsearchOperations);
+        verifyNoMoreInteractions(indexOperations);
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Deleting all documents of an index is inefficient and not recommended, instead we recreate the index (with the same name).



**What is the current behavior?**
<!-- You can also link to an open issue here -->
To recreate an index (e.g due to a change in the mapping), we delete all the documents contained in the index.


**What is the new behavior (if this is a feature change)?**
To recreate an index, we delete and recreate the index.

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
The endpoint to delete all documents of the index `@DeleteMapping(value = "/cases/indexation")` was replaced by `@PostMapping(value = "/cases/index/recreate")`
The new endpoint is used in https://github.com/gridsuite/admin-tools/pull/38