### PR TITLE
Add case uuid to getCaseInfos on error logs

### DIFF
--- a/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
+++ b/src/main/java/com/powsybl/caseserver/service/FsCaseService.java
@@ -127,7 +127,7 @@ public class FsCaseService implements CaseService {
             return getCaseInfos(file);
         } catch (Exception e) {
             // This method is called by getCases() that is a method for supervision and administration. We do not want the request to stop and fail on error cases.
-            LOGGER.error("Error processing file {}: {}", file.getFileName(), e.getMessage(), e);
+            LOGGER.error("Error processing file {} in directory {}: {}", file.getFileName(), file.getParent().getFileName(), e.getMessage(), e);
             return null;
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Log improvement


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Error logs are like:
`Error processing file situ.xiidm : For input string: "P"`


**What is the new behavior (if this is a feature change)?**
Error logs are like:
`Error processing file situ.xiidm in directory ad283f0a-2217-4bc8-beff-07f6d8647be3: For input string: "P"`
