### PR TITLE
Update GitHub workflow secrets and use correct environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: powsybl/github-ci/.github/workflows/build-backend-app-generic.yml@c81718897ef649fcdc685955a094bf724bf7fa9e
+    uses: powsybl/github-ci/.github/workflows/build-backend-app-generic.yml@27de863e5794d59dad7cecf85157f3d55511a5aa
     with:
       dockerImage: docker.io/powsybl/case-server
       dockerUsername: powsyblci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,6 @@ jobs:
       dockerUsername: powsyblci
       eventOrganizations: gridsuite
       eventType: case_server_updated
-      environment: ''
     secrets:
       sonar-token: ${{ secrets.SONAR_TOKEN }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/dockerdeploy.yml
+++ b/.github/workflows/dockerdeploy.yml
@@ -9,4 +9,4 @@ jobs:
       dockerImage: docker.io/powsybl/case-server
       dockerUsername: powsyblci
     secrets:
-      DOCKER_RELEASE: ${{ secrets.DOCKER_RELEASE }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/dockerdeploy.yml
+++ b/.github/workflows/dockerdeploy.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   run-deploy:
-    uses: powsybl/github-ci/.github/workflows/manual-dockerdeploy-backend-app-generic.yml@c81718897ef649fcdc685955a094bf724bf7fa9e
+    uses: powsybl/github-ci/.github/workflows/manual-dockerdeploy-backend-app-generic.yml@27de863e5794d59dad7cecf85157f3d55511a5aa
     with:
       dockerImage: docker.io/powsybl/case-server
       dockerUsername: powsyblci

--- a/.github/workflows/sonarcloud-maven-tag-analysis.yml
+++ b/.github/workflows/sonarcloud-maven-tag-analysis.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   build:
-    uses: powsybl/github-ci/.github/workflows/sonarcloud-maven-tag-analysis.yml@5e7bee4d67fe4e15e15be7ee6b4ef14aff2ed701
+    uses: powsybl/github-ci/.github/workflows/sonarcloud-maven-tag-analysis.yml@27de863e5794d59dad7cecf85157f3d55511a5aa
     secrets:
       sonar-token: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Replaced `DOCKER_RELEASE` with `DOCKERHUB_TOKEN` for consistency across workflows and use default environment `release` instead of overriding it.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Use DOCKER_RELEASE and no environment


**What is the new behavior (if this is a feature change)?**
Use DOCKERHUB_TOKEN and `release` environment