### PR TITLE
case download restore browser download progress bar instead of indeterminate

### DIFF
--- a/src/main/java/com/powsybl/caseserver/CaseController.java
+++ b/src/main/java/com/powsybl/caseserver/CaseController.java
@@ -29,8 +29,9 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -97,17 +98,24 @@ public class CaseController {
     @Operation(summary = "Download a case")
     public ResponseEntity<Resource> downloadCase(@PathVariable("caseUuid") UUID caseUuid) {
         LOGGER.debug("getCase request received with parameter caseUuid = {}", caseUuid);
-        Optional<InputStream> caseStreamOpt = caseService.getCaseStream(caseUuid);
+        Optional<ResponseInputStream<GetObjectResponse>> caseStreamOpt = caseService.getCaseStream(caseUuid);
         if (caseStreamOpt.isEmpty()) {
             return ResponseEntity.noContent().build();
         }
+        ResponseInputStream<GetObjectResponse> caseStream = caseStreamOpt.get();
         String name = caseService.getCaseName(caseUuid);
         Boolean isUploadedAsPlainFile = caseService.isUploadedAsPlainFile(caseUuid);
         HttpHeaders headers = buildHeaders(name, isUploadedAsPlainFile);
+        // Setting the content length lets the browser display a determinate download progress instead
+        // of an indeterminate one.
+        Long contentLength = caseStream.response().contentLength();
+        if (contentLength != null) {
+            headers.setContentLength(contentLength);
+        }
         return ResponseEntity.ok()
                 .headers(headers)
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
-                .body(new InputStreamResource(caseStreamOpt.get()));
+                .body(new InputStreamResource(caseStream));
     }
 
     @GetMapping(value = "/cases/{caseUuid}/exists")

--- a/src/main/java/com/powsybl/caseserver/service/CaseService.java
+++ b/src/main/java/com/powsybl/caseserver/service/CaseService.java
@@ -269,7 +269,7 @@ public class CaseService {
         return UUID.fromString(keyWithoutRootDirectory.substring(0, firstSlash));
     }
 
-    public Optional<InputStream> getCaseStream(UUID caseUuid) {
+    public Optional<ResponseInputStream<GetObjectResponse>> getCaseStream(UUID caseUuid) {
         try {
             return getCaseStream(uuidToKeyWithOriginalFileName(caseUuid));
         } catch (CaseRuntimeException | ResponseStatusException e) {
@@ -278,7 +278,7 @@ public class CaseService {
         }
     }
 
-    public Optional<InputStream> getCaseStream(String caseFileKey) {
+    public Optional<ResponseInputStream<GetObjectResponse>> getCaseStream(String caseFileKey) {
         try {
             GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucketName)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
no


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
bugfix/feature: browser download progress bar for case download


**What is the current behavior?**
<!-- You can also link to an open issue here -->
<img width="585" height="55" alt="image" src="https://github.com/user-attachments/assets/8b66ac42-fd9c-4efe-952e-a7168a7c5115" />



**What is the new behavior (if this is a feature change)?**
<img width="927" height="93" alt="image" src="https://github.com/user-attachments/assets/d0683746-befc-4844-b97c-952231128d25" />



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
We just have to forward the available contentLength from s3 to the incoming request.
